### PR TITLE
fix activity icon size

### DIFF
--- a/activity/activity-flipsticks.svg
+++ b/activity/activity-flipsticks.svg
@@ -6,7 +6,7 @@
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#FFFFFF">
 ]>
-<svg  version="1.1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="60.818" height="55.881" viewBox="0 0 60.818 55.881"
+<svg version="1.1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="55" height="55" viewBox="0 0 60.818 55.881"
 	 overflow="visible" enable-background="new 0 0 60.818 55.881" xml:space="preserve">
 	<g transform="translate(6.5,4)">
 	<g transform="scale(0.84)">


### PR DESCRIPTION
icon size of the activity was not of standard size all activities of sugar has icon size of 55x55.

This was causing problem in porting this activity to flatpak.